### PR TITLE
Change the way to set the cwd on newly spawned terminals

### DIFF
--- a/cwd_spawn.lua
+++ b/cwd_spawn.lua
@@ -20,7 +20,7 @@ return function(max_count)
         while count < max_count and path and path:len() > 0 do
             local successful, dir_readable = pcall(function() return gfs.dir_readable(path) end)
             if successful and dir_readable then
-                awful.spawn(terminal.." -cd '"..path.."'")
+                awful.spawn.with_shell("cd '"..path.."';"..terminal)
                 return
             end
             path = path:match("(.*)[^%w][%w]*")


### PR DESCRIPTION
Recently I switch to a different terminal emulator (alacritty) and this feature
stop working properly (in fact I was not able to launch any new terminal). 

The problem is that the "-cd" flag is not present on other emulators, like alacritty
or kitty, so instead of supporting every one individually, I change the approach to
this one (a little uglier, I'm afraid)
